### PR TITLE
Add from_axis_angle_deg() and fix sign

### DIFF
--- a/pedemath/matrix.py
+++ b/pedemath/matrix.py
@@ -11,6 +11,7 @@ from numpy import array
 from numpy import dot
 
 from pedemath.vec3 import _float_almost_equal
+from pedemath.vec3 import normalize_v3
 from pedemath.vec3 import Vec3
 
 _np_column_major_order = "F"
@@ -261,18 +262,18 @@ class Matrix44(object):
         self.data.flat[:] = data_array
 
     @staticmethod
-    def from_axis_angle(axis, angle):
-        c = math.cos(angle)
-        s = math.sin(angle)
+    def from_axis_angle_deg(axis, angle_deg):
+        return Matrix44.from_axis_angle_rad(axis, angle_deg * math.pi / 180.)
+
+    @staticmethod
+    def from_axis_angle_rad(axis, angle_rad):
+
+        c = math.cos(angle_rad)
+        s = math.sin(angle_rad)
         t = 1.0 - c
+
         # normalize
-        axis_length = axis.length()
-
-        #raise if length is < 0?
-
-        axis.x /= axis_length
-        axis.y /= axis_length
-        axis.z /= axis_length
+        axis = normalize_v3(axis)
 
         m = Matrix44()
         m.data[0][0] = c + axis.x*axis.x*t
@@ -281,16 +282,16 @@ class Matrix44(object):
 
         tmp1 = axis.x * axis.y * t
         tmp2 = axis.z * s
-        m.data[1][0] = tmp1 + tmp2
-        m.data[0][1] = tmp1 - tmp2
+        m.data[0][1] = tmp1 + tmp2
+        m.data[1][0] = tmp1 - tmp2
         tmp1 = axis.x * axis.z * t
         tmp2 = axis.y * s
-        m.data[2][0] = tmp1 - tmp2
-        m.data[0][2] = tmp1 + tmp2
+        m.data[0][2] = tmp1 - tmp2
+        m.data[2][0] = tmp1 + tmp2
         tmp1 = axis.y*axis.z*t
         tmp2 = axis.x*s
-        m.data[2][1] = tmp1 + tmp2
-        m.data[1][2] = tmp1 - tmp2
+        m.data[1][2] = tmp1 + tmp2
+        m.data[2][1] = tmp1 - tmp2
 
         return m
 

--- a/pedemath/tests/test_matrix.py
+++ b/pedemath/tests/test_matrix.py
@@ -340,3 +340,84 @@ class InvertAffineMat44TestCase(unittest.TestCase):
             combined_mat_inverse.almost_equal(
                 mat2_inverse * mat1_inverse, places=5))
 
+
+class Matrix44FromAxisAngleTestCase(unittest.TestCase):
+    """Test Matrix44.from_axis_angle_deg()."""
+
+    def test_x_rot(self):
+        """Test Matrix44.from_axis_angle_deg() with an x rotation."""
+
+        mat = Matrix44.from_axis_angle_deg(Vec3(1, 0, 0), 90)
+
+        # Column 0
+        self.assertAlmostEqual(mat.data[0][0], 1)
+        self.assertAlmostEqual(mat.data[0][1], 0)
+        self.assertAlmostEqual(mat.data[0][2], 0)
+        self.assertAlmostEqual(mat.data[0][3], 0)
+        # Column 1
+        self.assertAlmostEqual(mat.data[1][0], 0)
+        self.assertAlmostEqual(mat.data[1][1], 0)
+        self.assertAlmostEqual(mat.data[1][2], 1)
+        self.assertAlmostEqual(mat.data[1][3], 0)
+        # Column 2
+        self.assertAlmostEqual(mat.data[2][0], 0)
+        self.assertAlmostEqual(mat.data[2][1], -1)
+        self.assertAlmostEqual(mat.data[2][2], 0)
+        self.assertAlmostEqual(mat.data[2][3], 0)
+        # Column 3
+        self.assertAlmostEqual(mat.data[3][0], 0)
+        self.assertAlmostEqual(mat.data[3][1], 0)
+        self.assertAlmostEqual(mat.data[3][2], 0)
+        self.assertAlmostEqual(mat.data[3][3], 1)
+
+    def test_y_rot(self):
+        """Test Matrix44.from_axis_angle_deg() with a y rotation."""
+
+        mat = Matrix44.from_axis_angle_deg(Vec3(0, 1, 0), 90)
+
+        # Column 0
+        self.assertAlmostEqual(mat.data[0][0], 0)
+        self.assertAlmostEqual(mat.data[0][1], 0)
+        self.assertAlmostEqual(mat.data[0][2], -1)
+        self.assertAlmostEqual(mat.data[0][3], 0)
+        # Column 1
+        self.assertAlmostEqual(mat.data[1][0], 0)
+        self.assertAlmostEqual(mat.data[1][1], 1)
+        self.assertAlmostEqual(mat.data[1][2], 0)
+        self.assertAlmostEqual(mat.data[1][3], 0)
+        # Column 2
+        self.assertAlmostEqual(mat.data[2][0], 1)
+        self.assertAlmostEqual(mat.data[2][1], 0)
+        self.assertAlmostEqual(mat.data[2][2], 0)
+        self.assertAlmostEqual(mat.data[2][3], 0)
+        # Column 3
+        self.assertAlmostEqual(mat.data[3][0], 0)
+        self.assertAlmostEqual(mat.data[3][1], 0)
+        self.assertAlmostEqual(mat.data[3][2], 0)
+        self.assertAlmostEqual(mat.data[3][3], 1)
+
+    def test_z_rot(self):
+        """Test Matrix44.from_axis_angle_deg() with a z rotation."""
+
+        mat = Matrix44.from_axis_angle_deg(Vec3(0, 0, 1), 90)
+
+        # Column 0
+        self.assertAlmostEqual(mat.data[0][0], 0)
+        self.assertAlmostEqual(mat.data[0][1], 1)
+        self.assertAlmostEqual(mat.data[0][2], 0)
+        self.assertAlmostEqual(mat.data[0][3], 0)
+        # Column 1
+        self.assertAlmostEqual(mat.data[1][0], -1)
+        self.assertAlmostEqual(mat.data[1][1], 0)
+        self.assertAlmostEqual(mat.data[1][2], 0)
+        self.assertAlmostEqual(mat.data[1][3], 0)
+        # Column 2
+        self.assertAlmostEqual(mat.data[2][0], 0)
+        self.assertAlmostEqual(mat.data[2][1], 0)
+        self.assertAlmostEqual(mat.data[2][2], 1)
+        self.assertAlmostEqual(mat.data[2][3], 0)
+        # Column 3
+        self.assertAlmostEqual(mat.data[3][0], 0)
+        self.assertAlmostEqual(mat.data[3][1], 0)
+        self.assertAlmostEqual(mat.data[3][2], 0)
+        self.assertAlmostEqual(mat.data[3][3], 1)


### PR DESCRIPTION
Matrix44.from_axis_angle() was assuming radians for the input angle, but that
is different than the convention of using degrees in thes module.

Add from_axis_angle_deg() and from_axis_angle_rad().
Might make a from_axis_angle the defaults to degrees, but will wait for
now to so it's obvious if that would break anything.

Also, flip the signs (same as switching the matrix index order).
The resulting signs for x, y, and z incorrectly negative until this change.

Also add minimal tests for from_axis_angle_deg()