### PR TITLE
Fix variables names in Quat.from_matrix44() for small numbers

### DIFF
--- a/pedemath/quat.py
+++ b/pedemath/quat.py
@@ -262,21 +262,24 @@ class Quat(object):
         # TODO: unittests for code below when trace is small.
 
         # matrix trace <= 0
-        if a[0][0] > a[1][1] and a[0][0] > a[2][2]:
-            s = 2.0 * math.sqrt(1.0 + a[0][0] - a[1][1] - a[2][2])
-            return Quat(n4 / 4.0,                             # x
+        if mat.data[0][0] > mat.data[1][1] and mat.data[0][0] > mat.data[2][2]:
+            s = 2.0 * math.sqrt(1.0 + mat.data[0][0] - mat.data[1][1] -
+                                mat.data[2][2])
+            return Quat(s / 4.0,                              # x
                         mat.data[1][0] + mat.data[0][1] / s,  # y
                         mat.data[2][0] + mat.data[0][2] / s,  # z
                         mat.data[2][1] - mat.data[1][2] / s)  # w
-        elif a[1][1] > a[2][2]:
-            s = 2.0 * math.sqrt(1.0 - a[0][0] + a[1][1] - a[2][2])
+        elif mat.data[1][1] > mat.data[2][2]:
+            s = 2.0 * math.sqrt(1.0 - mat.data[0][0] + mat.data[1][1] -
+                                mat.data[2][2])
             return Quat(mat.data[1][0] + mat.data[0][1] / s,  # x
-                        n4 / 4.0,                             # y
+                        s / 4.0,                              # y
                         mat.data[2][1] + mat.data[1][2] / s,  # z
                         mat.data[2][0] - mat.data[0][2] / s)  # w
         else:
-            s = 2.0 * math.sqrt(1.0 - a[0][0] - a[1][1] + a[2][2])
+            s = 2.0 * math.sqrt(1.0 - mat.data[0][0] - mat.data[1][1] +
+                                mat.data[2][2])
             return Quat(mat.data[2][0] + mat.data[0][2] / s,  # x
                         mat.data[2][1] + mat.data[1][2] / s,  # y
-                        n4 / 4.0,                             # z
+                        s / 4.0,                              # z
                         mat.data[1][0] - mat.data[0][1] / s)  # w


### PR DESCRIPTION
The code for small matrix traces is not hit often.  Fix variable
names, but it still needs unittests.